### PR TITLE
Initial converter from Crescat to Directus eventType

### DIFF
--- a/src/scripts/crescatToDirectusEvent/crescatToDirectusEvent.js
+++ b/src/scripts/crescatToDirectusEvent/crescatToDirectusEvent.js
@@ -1,0 +1,54 @@
+/**
+ * Convert a list of crescatEvents to the desired DirectusEvent format
+ * @param {CrescatEvent[]} crescatEvents
+ * @returns {DirectusEvent[]}
+ */
+function convertCrescatEventsToDirectusEvents(crescatEvents) {
+  /** @type {DirectusEvent[]} */
+  const out = []
+
+  for (const crescatEvent of crescatEvents) {
+    /**
+     * @type {DirectusEvent}
+     */
+    const directusEvent = {
+      internal_name: crescatEvent.name,
+      event_start: crescatEvent.start,
+      event_end: crescatEvent.end,
+      event_room: convertCrescatRoomsToDirectusRooms(crescatEvent.rooms),
+    }
+
+    out.push(directusEvent)
+  }
+
+  return out
+}
+
+/**
+ *
+ * @param {CrescatRoom[]} crescatRooms
+ * @returns {EventRoom[]}
+ */
+function convertCrescatRoomsToDirectusRooms(crescatRooms) {
+  /**
+   * @type {EventRoom[]}
+   */
+  const out = []
+
+  for (const crescatRoom of crescatRooms) {
+    /**@type {EventRoom} */
+    const eventRoom = {
+      room_id: {
+        id: crescatRoom.id,
+        name: crescatRoom.name,
+      },
+    }
+    out.push(eventRoom)
+  }
+
+  return out
+}
+
+// export default convertCrescatEventsToDirectusEvents
+
+module.exports = convertCrescatEventsToDirectusEvents

--- a/src/scripts/crescatToDirectusEvent/crescatToDirectusEvent.spec.js
+++ b/src/scripts/crescatToDirectusEvent/crescatToDirectusEvent.spec.js
@@ -1,0 +1,81 @@
+const crescatToDirectusEvent = require('./crescatToDirectusEvent')
+
+/** @type {CrescatEvent[]} */
+const sampleCrescatEvents = [
+  {
+    name: 'M\u00f8te, SKiBAS',
+    start: '2021-10-05 08:30:00',
+    end: '2021-10-05 10:30:00',
+    event_type_id: null,
+    rooms: [
+      {
+        name: 'Stillhet',
+        id: 118,
+        title: null,
+        start: '2021-10-05 08:30:00',
+        end: '2021-10-05 10:30:00',
+      },
+    ],
+    show_times: [],
+    fields: [],
+  },
+  {
+    name: 'BFK: Projector Calibration',
+    start: '2021-10-05 14:00:00',
+    end: '2021-10-05 23:00:00',
+    event_type_id: 138,
+    rooms: [
+      {
+        name: 'Tivoli',
+        id: 95,
+        title: null,
+        start: '2021-10-05 14:00:00',
+        end: '2021-10-05 23:00:00',
+      },
+    ],
+    show_times: [],
+    fields: [
+      {
+        value: null,
+        id: 70879,
+      },
+      {
+        value: null,
+        id: 70876,
+      },
+      {
+        value: null,
+        id: 70877,
+      },
+      {
+        value: null,
+        id: 70878,
+      },
+    ],
+  },
+]
+
+/** @type {DirectusEvent[]} */
+const expectedCrescatEvents = [
+  {
+    internal_name: 'Møte, SKiBAS',
+    event_start: '2021-10-05 08:30:00',
+    event_end: '2021-10-05 10:30:00',
+    event_room: [{ room_id: { id: 118, name: 'Stillhet' } }],
+  },
+  {
+    internal_name: 'BFK: Projector Calibration',
+    event_start: '2021-10-05 14:00:00',
+    event_end: '2021-10-05 23:00:00',
+    event_room: [{ room_id: { id: 95, name: 'Tivoli' } }],
+  },
+]
+
+if (
+  JSON.stringify(crescatToDirectusEvent(sampleCrescatEvents)) !=
+  JSON.stringify(expectedCrescatEvents)
+) {
+  throw new Error('crescatToDirectusEvent failed')
+} else {
+  console.info('crescatToDirectusEvent passed')
+}

--- a/src/scripts/crescatToDirectusEvent/typedef.js
+++ b/src/scripts/crescatToDirectusEvent/typedef.js
@@ -1,0 +1,56 @@
+/**
+ * @typedef {Object} CrescatEvent
+ * @property {string} name
+ * @property {Date} start
+ * @property {Date} end
+ * @property {number | null} event_type_id
+ * @property {CrescatRoom[]} rooms
+ * @property {any[]} show_times
+ * @property {CrescatField[]} fields
+ */
+
+/**
+ * @typedef {Object} CrescatField
+ * @property {number} id
+ * @property {any | null} value
+ */
+
+/**
+ * @typedef {Object} CrescatRoom
+ * @property {string} name
+ * @property {number} id
+ * @property {string | null} title
+ * @property {Date} start
+ * @property {Date} end
+ */
+
+/**
+ * @typedef {Object} DirectusEvent
+ * @property {string} id  Not in use in converter
+ * @property {string} internal_name
+ * @property {string} crescat_id Not available from Crescat
+ * @property {string} status Not in use in converter
+ * @property {string | null} ticket_url Not available from Crescat
+ * @property {string | null} facebook_url Not available from Crescat
+ * @property {Date} event_start
+ * @property {Date} event_end
+ * @property {Translation[]} translations Not available from Crescat
+ * @property {EventRoom[]} event_room
+ */
+
+/**
+ * @typedef {Object} EventRoom
+ * @property {RoomID} room_id
+ */
+
+/**
+ * @typedef {Object} RoomID
+ * @property {string} id
+ * @property {string} name
+ */
+
+/**
+ * @typedef {Object} Translation
+ * @property {string} title
+ * @property {string} description
+ */


### PR DESCRIPTION
Goal: Converter for converting CrescatEvents to DirectusEvents
Closes #26 

Missing:
- [ ] crescat_id is not supplied from crescat

But other than that I think it is mostly good.
Currently usable as a require module. But would probably be nice to have is as an ES module as well in final version