### PR TITLE
Prevent topbar to float over banner image

### DIFF
--- a/apps/kvarteret/components/Page.js
+++ b/apps/kvarteret/components/Page.js
@@ -62,7 +62,7 @@ const ComponentLookup = ({ type, data }) => {
     case "call_to_action_section":
       return <CallToActionSection {...data} />;
     case "rooms_section":
-      return <RoomSection {...data}/>
+      return <RoomSection {...data} />;
 
     default:
       return <div>TODO: Missing section types</div>;
@@ -87,7 +87,7 @@ const Page = ({ data }) => (
           max-width: 1080px;
           margin: auto;
           padding: 0 40px;
-          margin-top: 100px;
+          margin-top: 20px;
           margin-bottom: 40px;
         }
       `}

--- a/apps/kvarteret/pages/events/index.js
+++ b/apps/kvarteret/pages/events/index.js
@@ -197,7 +197,7 @@ const EventSearch = () => {
             margin: 20px;
           }
           .container {
-            margin-top: 100px;
+            margin-top: 20px;
             max-width: 1080px;
             width: 100%;
           }

--- a/packages/dak-components/lib/components/layout/Layout.js
+++ b/packages/dak-components/lib/components/layout/Layout.js
@@ -80,7 +80,7 @@ const Layout = ({ children, data }) => {
           .header-bar {
             height: 80px;
             width: 100%;
-            background-color: rgba(0, 0, 0, 0.7);
+            background-color: rgba(0, 0, 0, 1);
             box-shadow: 0 4px 4px rgb(0 0 0 / 40%);
             backdrop-filter: blur(4px);
           }

--- a/packages/dak-components/lib/components/layout/Layout.js
+++ b/packages/dak-components/lib/components/layout/Layout.js
@@ -68,6 +68,7 @@ const Layout = ({ children, data }) => {
 
           .content {
             flex: 1;
+            margin-top: 80px;
           }
 
           .header {


### PR DESCRIPTION
Fixes #98

<img width="1279" alt="image" src="https://github.com/kvarteret/kvarteret.no/assets/5204006/e5d9e459-e8ec-482d-87b6-0cec089ce84d">


<img width="1014" alt="image" src="https://github.com/kvarteret/kvarteret.no/assets/5204006/d674cb30-18c8-4d18-a017-7de6ddb42228">

When scrolling the topbar is still on top
<img width="885" alt="image" src="https://github.com/kvarteret/kvarteret.no/assets/5204006/86ec4a80-d6e2-4e1c-9528-076f495b7721">
