### PR TITLE
feat: read events from Sanity

### DIFF
--- a/apps/kvarteret/next.config.js
+++ b/apps/kvarteret/next.config.js
@@ -11,6 +11,7 @@ module.exports = withPlugins([withTM(), withImages], {
       "kvarteret-events.firebasestorage.app",
       "ydkxiragzzsaapnbnebm.supabase.co",
       "jeezqitchepgwxjknwhz.supabase.co",
+      "cdn.sanity.io",
     ],
   },
   rewrites: async () => [

--- a/apps/kvarteret/pages/events/[id].tsx
+++ b/apps/kvarteret/pages/events/[id].tsx
@@ -1,5 +1,6 @@
 import { BlurImage, ExternalContent } from "dak-components";
 import { format, isSameDay } from "date-fns";
+import { enGB, nb } from "date-fns/locale";
 import Snippet from "../../components/Snippet";
 import fetchLayoutData from "dak-components/lib/cms/layout";
 import queryAllEventSlugs, {
@@ -9,7 +10,6 @@ import queryAllEventSlugs, {
 } from "dak-components/lib/cms/queries/events";
 import { parseEventDateTime } from "dak-components/lib/eventDateTime";
 import isResourceAvailable from "dak-components/lib/cms/utils/statusUtils";
-import { getSupabaseEventBySlug } from "dak-components/lib/supabaseEvents";
 import { getTranslationsData } from "dak-components/lib/components/TranslatedField";
 import { InferGetStaticPropsType } from "next";
 
@@ -35,16 +35,7 @@ export async function getStaticProps({
   preview: boolean;
 }) {
   const layout = await fetchLayoutData(locale);
-  let data = await queryEventBySlug(locale, params.id);
-
-  // Try Supabase custom-feed events as fallback
-  if (!data || !isResourceAvailable(data.status, preview)) {
-    try {
-      data = await getSupabaseEventBySlug(params.id);
-    } catch (e) {
-      console.error(e);
-    }
-  }
+  const data = await queryEventBySlug(locale, params.id);
 
   if (!data || !isResourceAvailable(data.status, preview)) {
     return {
@@ -56,20 +47,42 @@ export async function getStaticProps({
     };
   }
 
-  const formatDate = () => {
-    const start = parseEventDateTime(data.event_start);
-    const end = parseEventDateTime(data.event_end);
+  const dateLocale = locale === "en" ? enGB : nb;
+
+  const formatDateRange = (startValue, endValue) => {
+    const start = parseEventDateTime(startValue);
+    const end = parseEventDateTime(endValue);
     if (isSameDay(start, end)) {
-      return `${format(start, "dd. MMMM yyyy 'kl.' HH:mm")} - ${format(
+      return `${format(start, "dd. MMMM yyyy 'kl.' HH:mm", {
+        locale: dateLocale,
+      })} - ${format(
         end,
-        "HH:mm"
+        "HH:mm",
+        { locale: dateLocale }
       )}`;
     }
 
-    return `${format(start, "dd. MMMM yyyy 'kl.' HH:mm")} - ${format(
+    return `${format(start, "dd. MMMM yyyy 'kl.' HH:mm", {
+      locale: dateLocale,
+    })} - ${format(
       end,
-      "dd. MMMM yyyy 'kl.' HH:mm"
+      "dd. MMMM yyyy 'kl.' HH:mm",
+      { locale: dateLocale }
     )}`;
+  };
+
+  const formatDate = () => {
+    if (data.sanity_dates?.length) {
+      return data.sanity_dates
+        .map((date) => {
+          const startDate = `${date.startDate}T${date.startTime || "00:00"}:00`;
+          const endDate = `${date.startDate}T${date.endTime || date.startTime || "00:00"}:00`;
+          return formatDateRange(startDate, endDate);
+        })
+        .join("\n");
+    }
+
+    return formatDateRange(data.event_start, data.event_end);
   };
 
   const translationOfEvent = getCorrectTranslation(data.translations, locale);
@@ -105,8 +118,17 @@ export async function getStaticProps({
                 {
                   icon: "dak-info-circled",
                   title: "Type",
-                  text: data.taxonomy_label,
+                  text: data.event_type?.name || data.taxonomy_label,
                 },
+                ...(data.organizer_groups?.length
+                  ? [
+                      {
+                        icon: "dak-group",
+                        title: "Arrangør",
+                        text: data.organizer_groups.map((group) => group.name).join(", "),
+                      },
+                    ]
+                  : []),
               ]
             : [
                 {
@@ -124,7 +146,7 @@ export async function getStaticProps({
             ? [
                 {
                   icon: "dak-clock",
-                  title: "Recurring",
+                  title: locale === "en" ? "Recurring" : "Gjentagelse",
                   text: data.recurring_label,
                 },
               ]
@@ -235,6 +257,7 @@ const PracticalInformationLine = ({
           .text {
             font-size: 16px;
             font-weight: 500;
+            white-space: pre-line;
           }
         `}
       </style>

--- a/packages/dak-components/lib/cms/events.ts
+++ b/packages/dak-components/lib/cms/events.ts
@@ -1,6 +1,6 @@
-import { getEventsFromSupabase } from "../supabaseEvents";
 import { parseEventDateTime } from "../eventDateTime";
-import { Event, Locale, queryAllEvents } from "./queries/events";
+import { getEventsFromSanity } from "../sanityEvents";
+import { Event, Locale } from "./queries/events";
 import { nb, enGB } from "date-fns/locale";
 import { format, formatRelative, parse } from "date-fns";
 
@@ -48,19 +48,9 @@ const getTimeText = (x: Event, lang: Locale) => {
   }
 };
 const getEventsAfter = async (lang: Locale, date: Date) => {
-  const upcomingEventsCmsPromise = queryAllEvents(date);
-  const upcomingEventsSupabasePromise = getEventsFromSupabase(date);
-
-  const [upcomingEventsCms, upcomingEventsSupabase] = await Promise.all([
-    upcomingEventsCmsPromise,
-    upcomingEventsSupabasePromise,
-  ]);
-
-  const upcomingEvents = upcomingEventsCms
-    .concat(upcomingEventsSupabase)
-    .sort((a, b) =>
-      parseEventDateTime(a.event_start) > parseEventDateTime(b.event_start) ? 1 : -1
-    );
+  const upcomingEvents = (await getEventsFromSanity(date)).sort((a, b) =>
+    parseEventDateTime(a.event_start) > parseEventDateTime(b.event_start) ? 1 : -1
+  );
   return upcomingEvents.map((x) => ({ ...x, duration: getTimeText(x, lang) }));
 };
 

--- a/packages/dak-components/lib/cms/queries/events.ts
+++ b/packages/dak-components/lib/cms/queries/events.ts
@@ -1,23 +1,16 @@
 import { gql } from "@apollo/client";
 import cmsClient from "../cmsClient";
-import appendBase64Image from "../utils/appendBase64Image";
 import { mergeDateWithEventTime, parseEventDateTime } from "../../eventDateTime";
 import isResourceAvailable from "dak-components/lib/cms/utils/statusUtils";
+import { getSanityEventBySlug, getSanityEventSlugs } from "../../sanityEvents";
 
 export default async function queryAllEventSlugs() {
-  const { data } = (await cmsClient.query({
-    query: gql`
-      query QueryAllEventSlugs {
-        events {
-          id
-          status
-          slug
-        }
-      }
-    `,
-  })) as unknown as { data: { events: EventWithSlug[] } };
-
-  return data.events.filter((x) => x.status === "published");
+  const slugs = await getSanityEventSlugs();
+  return slugs.map((slug) => ({
+    id: slug,
+    status: Status.Published,
+    slug,
+  }));
 }
 
 export async function queryAllEvents(filterDate = new Date()) {
@@ -43,17 +36,8 @@ export async function queryAllEvents(filterDate = new Date()) {
 }
 
 export async function queryEventBySlug(lang: Locale | string, slug: string) {
-  const { data } = (await cmsClient.query({
-    variables: { slug, lang },
-    query: gql`
-      query QueryEventById($slug: String) {
-        events(filter: { slug: { _eq: $slug } }) {
-          ${eventGraphQlQueryProps}
-        }
-      }
-    `,
-  })) as unknown as { data: { events: Event[] } };
-  return appendBase64Image<Event>(data.events[0]);
+  void lang;
+  return getSanityEventBySlug(slug);
 }
 
 const getBiggestDate = (a: Date, b: Date) => {
@@ -266,6 +250,13 @@ export interface Event {
   };
   categories?: { name: string }[];
   price?: string | null | number;
+  image_caption?: string | null;
+  sanity_dates?: {
+    _key?: string;
+    startDate?: string | null;
+    startTime?: string | null;
+    endTime?: string | null;
+  }[];
 }
 
 export type Weekday =

--- a/packages/dak-components/lib/components/BlurImage.js
+++ b/packages/dak-components/lib/components/BlurImage.js
@@ -12,6 +12,11 @@ export function BlurImage(props) {
   delete data.fadeIn;
   delete data.noLoad;
   const customLoader = ({ src, width, quality }) => {
+    if (origin === "sanity") {
+      const separator = src.includes("?") ? "&" : "?";
+      return `${src}${separator}w=${width}&q=${quality || 75}&auto=format`;
+    }
+
     if (origin === "firestore" || origin === "supabase") {
       // Event feeds store the full image URL directly
       return src;

--- a/packages/dak-components/lib/sanityEvents.ts
+++ b/packages/dak-components/lib/sanityEvents.ts
@@ -1,0 +1,341 @@
+import { Event, Translation } from "./cms/queries/events";
+
+const SANITY_PROJECT_ID =
+  process.env.NEXT_PUBLIC_SANITY_PROJECT_ID?.trim() || "mkjoahvv";
+const SANITY_DATASET =
+  process.env.NEXT_PUBLIC_SANITY_DATASET?.trim() || "production";
+const SANITY_API_VERSION = "2024-01-01";
+
+type SanityDate = {
+  _key?: string;
+  startDate?: string | null;
+  startTime?: string | null;
+  endTime?: string | null;
+};
+
+type SanityArrangement = {
+  _id: string;
+  title?: string | null;
+  slug?: string | null;
+  approvalStatus?: string | null;
+  isRecurring?: boolean | null;
+  rrule?: string | null;
+  dates?: SanityDate[] | null;
+  isFree?: boolean | null;
+  priceOrdinar?: number | null;
+  priceStudent?: number | null;
+  priceMedlem?: number | null;
+  ticketUrl?: string | null;
+  facebookUrl?: string | null;
+  imageUrl?: string | null;
+  imageCaption?: string | null;
+  room?: {
+    _id?: string | null;
+    title?: string | null;
+    slug?: string | null;
+    floor?: number | null;
+  } | null;
+  roomText?: string | null;
+  organizerGroup?: {
+    _id?: string | null;
+    name?: string | null;
+    slug?: string | null;
+  } | null;
+  organizerText?: string | null;
+  eventType?: {
+    _id?: string | null;
+    name?: string | null;
+    slug?: string | null;
+    taxonomyGroup?: {
+      name?: string | null;
+      slug?: string | null;
+    } | null;
+  } | null;
+  description?: PortableTextBlock[] | null;
+};
+
+type PortableTextBlock = {
+  _type?: string;
+  style?: string;
+  children?: { text?: string | null }[];
+};
+
+const arrangementProjection = `{
+  _id,
+  "title": coalesce(title, ""),
+  "slug": coalesce(slug.current, ""),
+  approvalStatus,
+  isRecurring,
+  rrule,
+  "dates": dates | order(startDate asc) {
+    _key,
+    "startDate": coalesce(startDate, ""),
+    startTime,
+    endTime
+  },
+  isFree,
+  priceOrdinar,
+  priceStudent,
+  priceMedlem,
+  ticketUrl,
+  facebookUrl,
+  "imageUrl": image.asset->url,
+  imageCaption,
+  "room": room-> {
+    _id,
+    "title": coalesce(title, ""),
+    "slug": coalesce(slug.current, ""),
+    floor
+  },
+  roomText,
+  "organizerGroup": organizerGroup-> {
+    _id,
+    "name": coalesce(name, ""),
+    "slug": coalesce(slug.current, "")
+  },
+  organizerText,
+  "eventType": eventType-> {
+    _id,
+    "name": coalesce(name, ""),
+    "slug": coalesce(slug.current, ""),
+    "taxonomyGroup": taxonomyGroup-> {
+      "name": coalesce(name, ""),
+      "slug": coalesce(slug.current, "")
+    }
+  },
+  description[] {
+    ...,
+    children[] { ..., text }
+  }
+}`;
+
+const publishedArrangementsQuery = `*[
+  _type == "arrangement"
+  && approvalStatus == "approved"
+  && (
+    count(dates[startDate >= $today]) > 0
+    || (isRecurring == true && defined(rrule) && count(dates) > 0)
+  )
+] | order(coalesce(dates[startDate >= $today][0].startDate, dates[0].startDate) asc) ${arrangementProjection}`;
+
+const arrangementBySlugQuery = `*[
+  _type == "arrangement"
+  && slug.current == $slug
+  && approvalStatus == "approved"
+][0] ${arrangementProjection}`;
+
+const arrangementSlugsQuery = `*[
+  _type == "arrangement"
+  && approvalStatus == "approved"
+  && defined(slug.current)
+].slug.current`;
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const portableTextToHtml = (blocks: PortableTextBlock[] | null | undefined) =>
+  (blocks ?? [])
+    .filter((block) => block?._type === "block")
+    .map((block) => {
+      const text = (block.children ?? [])
+        .map((child) => child.text ?? "")
+        .join("")
+        .trim();
+
+      if (!text) return "";
+
+      const tag = block.style?.startsWith("h") ? block.style : "p";
+      return `<${tag}>${escapeHtml(text)}</${tag}>`;
+    })
+    .filter(Boolean)
+    .join("");
+
+const getTodayKey = (date: Date) =>
+  new Intl.DateTimeFormat("sv-SE", {
+    timeZone: "Europe/Oslo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+
+const sanityFetch = async <T>(
+  query: string,
+  params: Record<string, string> = {}
+): Promise<T> => {
+  const url = new URL(
+    `/v${SANITY_API_VERSION}/data/query/${SANITY_DATASET}`,
+    `https://${SANITY_PROJECT_ID}.apicdn.sanity.io`
+  );
+  url.searchParams.set("query", query);
+
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(`$${key}`, JSON.stringify(value));
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to get events from Sanity (${response.status})`);
+  }
+
+  const body = (await response.json()) as { result: T };
+  return body.result;
+};
+
+const toEventDateTime = (
+  date: SanityDate | undefined,
+  key: "startTime" | "endTime"
+) => {
+  const startDate = date?.startDate || getTodayKey(new Date());
+  const time = date?.[key] || date?.startTime || "00:00";
+  return `${startDate}T${time}:00`;
+};
+
+const formatPrice = (arrangement: SanityArrangement): string | null => {
+  if (arrangement.isFree) return "Gratis";
+
+  const prices = [
+    arrangement.priceOrdinar != null ? `Ord. ${arrangement.priceOrdinar} kr` : null,
+    arrangement.priceStudent != null ? `Stud. ${arrangement.priceStudent} kr` : null,
+    arrangement.priceMedlem != null ? `Medl. ${arrangement.priceMedlem} kr` : null,
+  ].filter(Boolean);
+
+  return prices.length > 0 ? prices.join(" / ") : null;
+};
+
+const mapImage = (
+  imageUrl: SanityArrangement["imageUrl"]
+): { id: string; __typename: "sanity" } | null => {
+  if (!imageUrl) return null;
+
+  return {
+    id: imageUrl,
+    __typename: "sanity",
+  };
+};
+
+const mapTranslations = (arrangement: SanityArrangement): Translation[] => [
+  {
+    title: arrangement.title ?? arrangement.slug ?? "",
+    description: portableTextToHtml(arrangement.description),
+    practical_information: [],
+    snippets: [],
+    languages_code: { url_code: "no" },
+  },
+];
+
+const getOrganizerName = (arrangement: SanityArrangement) =>
+  arrangement.organizerGroup?.name || arrangement.organizerText || "";
+
+const getRoomName = (arrangement: SanityArrangement) =>
+  arrangement.room?.title || arrangement.roomText || "";
+
+const getPrimaryDate = (arrangement: SanityArrangement) => {
+  const today = getTodayKey(new Date());
+  return (
+    arrangement.dates?.find((date) => (date.startDate ?? "") >= today) ??
+    arrangement.dates?.[0]
+  );
+};
+
+const mapSanityArrangementToEvent = (arrangement: SanityArrangement): Event => {
+  const primaryDate = getPrimaryDate(arrangement);
+  const roomName = getRoomName(arrangement);
+  const organizerName = getOrganizerName(arrangement);
+  const eventTypeName = arrangement.eventType?.name || "";
+
+  return {
+    id: arrangement._id,
+    status: "published",
+    slug: arrangement.slug || arrangement._id,
+    event_start: toEventDateTime(primaryDate, "startTime"),
+    event_end: toEventDateTime(primaryDate, "endTime"),
+    ticket_url: arrangement.ticketUrl ?? null,
+    facebook_url: arrangement.facebookUrl ?? null,
+    top_image: mapImage(arrangement.imageUrl),
+    event_header: mapImage(arrangement.imageUrl),
+    room: roomName
+      ? [
+          {
+            room_id: {
+              name: roomName,
+              floor:
+                arrangement.room?.floor != null
+                  ? arrangement.room.floor.toString()
+                  : "",
+            },
+          },
+        ]
+      : [],
+    translations: mapTranslations(arrangement),
+    is_recurring: Boolean(arrangement.isRecurring),
+    weekly_recurring: null,
+    event_type: eventTypeName
+      ? {
+          name: eventTypeName,
+          slug: arrangement.eventType?.slug ?? "",
+        }
+      : null,
+    organizer_groups: organizerName
+      ? [
+          {
+            name: organizerName,
+            slug: arrangement.organizerGroup?.slug ?? undefined,
+          },
+        ]
+      : [],
+    taxonomy_label: [eventTypeName, organizerName].filter(Boolean).join(" / "),
+    recurring_label: arrangement.isRecurring ? "Gjentagende arrangement" : null,
+    is_internal: false,
+    is_featured: false,
+    organizer: organizerName ? { name: organizerName } : null,
+    categories: eventTypeName ? [{ name: eventTypeName }] : [],
+    price: formatPrice(arrangement),
+    image_caption: arrangement.imageCaption ?? null,
+    sanity_dates: arrangement.dates ?? [],
+  };
+};
+
+export async function getEventsFromSanity(afterDate: Date): Promise<Event[]> {
+  try {
+    const arrangements = await sanityFetch<SanityArrangement[]>(
+      publishedArrangementsQuery,
+      { today: getTodayKey(afterDate) }
+    );
+    return arrangements.map(mapSanityArrangementToEvent);
+  } catch (error) {
+    console.error("Unable to get events from Sanity", error);
+    return [];
+  }
+}
+
+export async function getSanityEventBySlug(slug: string): Promise<Event | null> {
+  try {
+    const arrangement = await sanityFetch<SanityArrangement | null>(
+      arrangementBySlugQuery,
+      { slug }
+    );
+
+    return arrangement ? mapSanityArrangementToEvent(arrangement) : null;
+  } catch (error) {
+    console.error("Unable to get event from Sanity by slug", error);
+    return null;
+  }
+}
+
+export async function getSanityEventSlugs(): Promise<string[]> {
+  try {
+    return await sanityFetch<string[]>(arrangementSlugsQuery);
+  } catch (error) {
+    console.error("Unable to get event slugs from Sanity", error);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- replace Kvarteret event list/detail fetching with the public Sanity arrangement dataset used by samfunnetibergen.no
- map Sanity arrangement fields into the existing Kvarteret event shape, including dates, room, type, organizer, price, ticket/Facebook links, and images
- render the new detail fields and allow Sanity CDN images through the existing image component

## Validation
- npm run build:kvarteret
- npm run lint --workspace=kvarteret
- curl -LsS http://localhost:3001/api/events verified Sanity-backed event payloads
- curl http://localhost:3001/events/tirsdagsquiz/ verified Sanity detail fields render

## Notes
- No read token is required; the events dataset is public. The implementation supports NEXT_PUBLIC_SANITY_PROJECT_ID and NEXT_PUBLIC_SANITY_DATASET overrides and defaults to the current public Samfunnet Sanity project/dataset.
- The repo pre-push hook runs root test, which currently fails because packages/dak-components has a test script that exits with "Error: run tests from root". Targeted lint/build checks above passed.